### PR TITLE
Revert "Bump twisted from 17.9.0 to 19.2.1"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ watchdog==0.8.3
 cookiecutter==1.5.1
 dnspython==1.15.0
 commons==0.7
-twisted==19.2.1
+twisted==17.9.0
 zope==4.0b1


### PR DESCRIPTION
Reverts egis/papertrail-python-cli#77